### PR TITLE
Fix warnings RE: getDefaultProps in development

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -35,6 +35,12 @@ const config = {
       commonjs2: 'react-dom',
       amd: 'react-dom'
     },
+    'create-react-class': {
+      root: 'createReactClass',
+      commonjs: 'create-react-class',
+      commonjs2: 'create-react-class',
+      amd: 'create-react-class'
+    },
     'react/addons': 'React',
     moment: 'moment'
   },

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -1,10 +1,16 @@
 const webpackCommon = require('./webpack.common.config');
 
-const config =  {
+const config = {
   entry: {
-    'react-data-grid/dist/react-data-grid': ['./packages/react-data-grid/src'],
+    'react-data-grid/dist/react-data-grid': [
+      './node_modules/create-react-class/create-react-class.js',
+      './packages/react-data-grid/src'
+    ],
     'react-data-grid-addons/dist/react-data-grid-addons': ['./packages/react-data-grid-addons/src'],
-    'react-data-grid/dist/react-data-grid.min': ['./packages/react-data-grid/src'],
+    'react-data-grid/dist/react-data-grid.min': [
+      './node_modules/create-react-class/create-react-class.min.js',
+      './packages/react-data-grid/src'
+    ],
     'react-data-grid-addons/dist/react-data-grid-addons.min': ['./packages/react-data-grid-addons/src'],
     'react-data-grid-examples/dist/shared': './packages/react-data-grid-examples/src/shared.js',
     'react-data-grid-examples/dist/examples': './packages/react-data-grid-examples/src/examples.js',
@@ -19,4 +25,4 @@ const config =  {
   }
 };
 
-module.exports = Object.assign({ }, webpackCommon, config);
+module.exports = Object.assign({}, webpackCommon, config);


### PR DESCRIPTION
Don't include the minified version of `create-react-class` in development builds. This spits out useless and incorrect warnings about `getDefaultProps`.